### PR TITLE
correctly prevent subtitles in alternative views

### DIFF
--- a/hyper-video.html
+++ b/hyper-video.html
@@ -349,8 +349,10 @@ TODO document JSON format
               return;
             }
             var newTrack = track.cloneNode();
-            newTrack.track.mode = 'hidden';
             _video.appendChild(newTrack);
+            newTrack.addEventListener("load", function(evt) {
+                newTrack.track.mode = 'disabled';
+            });
           });
 
         });

--- a/hyper-video.html
+++ b/hyper-video.html
@@ -349,10 +349,10 @@ TODO document JSON format
               return;
             }
             var newTrack = track.cloneNode();
-            _video.appendChild(newTrack);
-            newTrack.addEventListener("load", function(evt) {
+            newTrack.addEventListener('load', function() {
                 newTrack.track.mode = 'disabled';
             });
+            _video.appendChild(newTrack);
           });
 
         });


### PR DESCRIPTION
When starting a hyper-video with subtitles and alternative views, the alternative views display the subtitles, which is not intended.
It seems that the problem comes from setting `track.mode` before the track is actually loaded.
